### PR TITLE
Fixing scenarios where the referenceId returned from Brightcove for a…

### DIFF
--- a/ios/BrightcovePlayerUtil.m
+++ b/ios/BrightcovePlayerUtil.m
@@ -153,11 +153,15 @@ RCT_EXPORT_METHOD(getPlaylistWithReferenceId:(NSString *)referenceId accountId:(
         if (!description) {
             description = @"";
         }
+	NSString *referenceId = video.properties[kBCOVVideoPropertyKeyReferenceId];
+        if (!referenceId) {
+            referenceId = @"";
+        }
         [videos addObject:
          @{
            kPlaylistAccountId: video.properties[kBCOVVideoPropertyKeyAccountId],
            kPlaylistVideoId: video.properties[kBCOVVideoPropertyKeyId],
-           kPlaylistReferenceId: video.properties[kBCOVVideoPropertyKeyReferenceId],
+           kPlaylistReferenceId: referenceId,
            kPlaylistName: name,
            kPlaylistDescription: description,
            kPlaylistDuration: video.properties[kBCOVVideoPropertyKeyDuration]


### PR DESCRIPTION
This ensures an assignment of empty string to cover scenarios where the video referenceId sent from Brightcove can be null. Since, referenceId is not a mandatory field for the video cloud studio.